### PR TITLE
Use view blocks in the PdfView class for outputing the pdf file

### DIFF
--- a/View/PdfView.php
+++ b/View/PdfView.php
@@ -96,9 +96,9 @@ class PdfView extends View {
 
 			$this->response->download($filename);
 		}
-		$this->output = $this->renderer()->output($content);
 
-		return $this->output;
+		$this->Blocks->set('content', $this->renderer()->output($content));
+		return $this->Blocks->get('content');
 	}
 
 }

--- a/readme.textile
+++ b/readme.textile
@@ -13,7 +13,7 @@ Current engines:
 h2. Requirements
 
 * PHP 5.2.8
-* CakePHP 2.x
+* CakePHP 2.1+
 * wkhtmltopdf (optional) See: http://code.google.com/p/wkhtmltopdf/
 * pdftk (optional) See: http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/
 


### PR DESCRIPTION
I was having issues where the PDF file contained the html rather than the generated PDF. This fixes that problem by replacing the outputted content with the PDF file.

Due to the use of view blocks it only works in CakePHP 2.1 and above.
