### PR TITLE
Fixing command to checkout the right CakePHP version on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
   - CAKE_VERSION=2.4
 
 before_script:
-  - git clone --depth 1 git://github.com/cakephp/cakephp ../cakephp && cd ../cakephp && git checkout $CAKE_VERSION
+  - git clone --depth 1 --branch $CAKE_VERSION git://github.com/cakephp/cakephp ../cakephp && cd ../cakephp
   - cp -R ../CakePdf plugins/CakePdf
 
 script:


### PR DESCRIPTION
Travis output says:

```
error: pathspec '2.2.7' did not match any file(s) known to git.
The command "git checkout $CAKE_VERSION" failed and exited with 1 during before_script.
```

That's because when cloning with '--depth 1' it doesn't retrieves branches/tags references (on git 1.8.1 and newer).
