### PR TITLE
Set explicit installer-name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,5 +7,8 @@
 	"require": {
 		"php": ">=5.3.0",
 		"composer/installers": "*"
+	},
+	"extra": {
+		"installer-name": "CakePdf"
 	}
 }


### PR DESCRIPTION
so that it will be installed to Plugin/CakePdf instead of Plugin/Cakepdf
