### PR TITLE
update readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current engines:
 * DomPdf
 * Mpdf
 * Tcpdf
-* Wkhtmltopdf (requires additional installation) **RECOMMENDED ENGINE**
+* WkHtmlToPdf (requires additional installation) **RECOMMENDED ENGINE**
 
 
 ## Requirements
@@ -17,6 +17,7 @@ Current engines:
 * CakePHP 2.1+
 * wkhtmltopdf (optional) See: http://code.google.com/p/wkhtmltopdf/
 * pdftk (optional) See: http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/
+* fonts (optional) If on linux system and your content contains cjk character, cjk fonts are required
 
 
 ## Installation


### PR DESCRIPTION
Its better to make the supported engine names case sensitive, because when I copy & pases, case insensitive engine names will cause stupid errors.

Another change is adding fonts as a requirement, when I am using the lib on a ubuntu system to generate pdf that contains Chinese content, certain fonts are required to render properly.
