### PR TITLE
so that PdfConfig['options'] is merged rather then replaced

### DIFF
--- a/View/PdfView.php
+++ b/View/PdfView.php
@@ -49,7 +49,7 @@ class PdfView extends View {
 	public function __construct(Controller $Controller = null) {
 		$this->_passedVars[] = 'pdfConfig';
 		parent::__construct($Controller);
-		$this->pdfConfig = array_merge(
+		$this->pdfConfig = array_merge_recursive(
 			(array)Configure::read('Pdf'),//BC line, remove later @todo
 			(array)Configure::read('CakePdf'),
 			(array)$this->pdfConfig


### PR DESCRIPTION
If my controller has:
```
$this->pdfConfig = array(
        'options' => array(
                'footer-html' => '/pdfparts/foot/' . $id,
            ),
        );
```
This change means that my existing configuration options:
```
Configure::write('CakePdf', array(
    'engine' => 'CakePdf.WkHtmlToPdf',
    'options' => array(
        'print-media-type' => false,
        'outline' => true,
        'dpi' => 96,
        'header-spacing' => 30,
    ),
    'margin' => array(
        'bottom' => 10,
        'left' => 10,
        'right' => 10,
        'top' => 45
    ),
    'orientation' => 'portrait',
    'download' => true,
));
```
won't be overwritten. They'll be merged instead.
