### PR TITLE
Update WkHtmlToPdfEngine.php

### DIFF
--- a/src/Pdf/Engine/WkHtmlToPdfEngine.php
+++ b/src/Pdf/Engine/WkHtmlToPdfEngine.php
@@ -61,7 +61,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
     {
         $result = ['stdout' => '', 'stderr' => '', 'return' => ''];
 
-        $proc = proc_open($cmd, [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+        $proc = proc_open($cmd, [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'a']], $pipes);
         fwrite($pipes[0], $input);
         fclose($pipes[0]);
 


### PR DESCRIPTION
with 'w' on stderr I get this message on OS X:
System error
wkhtmltopdf[26063:7773585] __agent_connection_block_invoke_2: Connection error - Connection invalid

changing it to 'a' solves the problem