### PR TITLE
Create request object from current globals (fix)

### DIFF
--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -806,7 +806,7 @@ class CakePdf
     {
         $viewClass = $this->viewRender();
         $viewClass = App::className($viewClass, 'View', $viewClass == 'View' ? '' : 'View');
-        $View = new $viewClass(new Request());
+        $View = new $viewClass(Request::createFromGlobals());
         $View->viewVars = $this->_viewVars;
         $View->theme = $this->_theme;
         $View->layoutPath = 'pdf';


### PR DESCRIPTION
The request object must be created from current globals, otherwise the UrlHelper will have wrong fullPath and the absolute paths to CSS and JS files will be wrong if the project is nested in some subdirectory.