### PR TITLE
Fixes for CakePHP 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ Example:
         //in your Invoices controller you could set additional configs, or override the global ones:
         public function view($id = null) {
             $invoice = $this->Invoice->get($id);
-            $this->pdfConfig = array(
-                'orientation' => 'portrait',
-                'filename' => 'Invoice_' . $id
-            );
+            $this->viewBuilder()->options([
+                'pdfConfig' => [
+                    'orientation' => 'portrait',
+                    'filename' => 'Invoice_' . $id
+                ]
+            ]);
             $this->set('invoice', $invoice);
         }
     }

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -7,7 +7,7 @@ EventManager::instance()
         function (Cake\Event\Event $event) {
             $controller = $event->subject();
             if ($controller->components()->has('RequestHandler')) {
-                $controller->RequestHandler->viewClassMap('pdf', 'CakePdf.Pdf');
+                $controller->RequestHandler->config('viewClassMap', ['pdf' => 'CakePdf.Pdf']);
             }
         }
     );


### PR DESCRIPTION
Documentation Fix for CakePHP 3.1

CakePHP 3.1 does not pass ```$this->pdfConfig``` to the view from the controller.

 
 