### PR TITLE
Overwrite binary path if set in configuation

### DIFF
--- a/Lib/Pdf/Engine/WkHtmlToPdfEngine.php
+++ b/Lib/Pdf/Engine/WkHtmlToPdfEngine.php
@@ -9,6 +9,20 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine {
  * @var string
  */
 	protected $_binary = '/usr/bin/wkhtmltopdf';
+	
+/**
+ * Constructor
+ * 
+ * Overwrite WkHtmlToPdf binary path if set in configuation.
+ *
+ * @param CakePdf $Pdf  CakePdf instance.
+ */	
+	public function __construct(CakePdf $Pdf) {
+		parent::__construct($Pdf);
+		if (Configure::check('CakePdf.binary')) {
+			$this->binary = Configure::read('CakePdf.binary');
+		}
+	}
 
 /**
  * Generates Pdf from html


### PR DESCRIPTION
Previously it ignored this WkHtmlToPdf specific configuration setting if instantiated manually.

If instantiated through PdfView, this does not happen because it merges the configuration:

```` php
$this->pdfConfig = array_merge(
	(array)Configure::read('CakePdf'),
	(array)$this->pdfConfig
);
````

https://github.com/FriendsOfCake/CakePdf/blob/develop/View/PdfView.php#L52