### PR TITLE
Composer failure with "3.0.x-dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ following to your `composer.json` file:
 
 ```javascript
 "require": {
-    "friendsofcake/cakepdf": "3.0.x-dev"
+    "friendsofcake/cakepdf": "~3.0"
 }
 ```
 


### PR DESCRIPTION
With the installation instructions in the readme, composer would complain:

"Your requirements could not be resolved to an installable set of packages."

Replaced the requirement above with "~3.0" and installation progressed normally.