### PR TITLE
Do not try to render again on empty content.

### DIFF
--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -229,7 +229,7 @@ class CakePdf
     /**
      * Create pdf content from html. Can be used to write to file or with PdfView to display
      *
-     * @param mixed $html Html content to render. If left empty, the template will be rendered with viewVars and layout that have been set.
+     * @param null|string $html Html content to render. If omitted, the template will be rendered with viewVars and layout that have been set.
      * @throws \Cake\Core\Exception\Exception
      * @return string
      */
@@ -240,7 +240,7 @@ class CakePdf
             throw new Exception(__d('cake_pdf', 'Engine is not loaded'));
         }
 
-        if (!$html) {
+        if ($html === null) {
             $html = $this->_render();
         }
         $this->html($html);

--- a/tests/TestCase/Pdf/CakePdfTest.php
+++ b/tests/TestCase/Pdf/CakePdfTest.php
@@ -79,6 +79,10 @@ class CakePdfTest extends TestCase
         $html = '<h2>Title</h2>';
         $result = $pdf->output($html);
         $this->assertEquals($html, $result);
+
+        $html = '';
+        $result = $pdf->output($html);
+        $this->assertEquals($html, $result);
     }
 
     /**

--- a/tests/TestCase/View/PdfViewTest.php
+++ b/tests/TestCase/View/PdfViewTest.php
@@ -92,4 +92,15 @@ class PdfViewTest extends TestCase
         $this->assertTrue(strpos($result, '<h2>Rendered with default layout</h2>') !== false);
         $this->assertTrue(strpos($result, 'Post data: This is the post') !== false);
     }
+
+    /**
+     * Test rendering a template that does not generate any output
+     *
+     */
+    public function testRenderTemplateWithNoOutput()
+    {
+        $this->View->viewPath = 'Posts';
+        $result = $this->View->render('empty', 'empty');
+        $this->assertEquals('', $result);
+    }
 }

--- a/tests/test_app/Template/Layout/pdf/empty.ctp
+++ b/tests/test_app/Template/Layout/pdf/empty.ctp
@@ -1,0 +1,1 @@
+<?= $this->fetch('content'); ?>


### PR DESCRIPTION
A template rendered by the PDF view might not generate any output under specific circumstances, this should not trigger the alternate rendering mechanism, as it will fail hard when no template has been set for the `CakePdf` instance in use (it will ultimately throw a missing template exception that complains about the lack of the file `Pdf/.ctp`).