### PR TITLE
Add options support to the DomPdf engine.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
   - sudo touch /usr/bin/latexpdf && sudo chmod +x /usr/bin/latexpdf
 
   - composer self-update
+  - composer require dompdf/dompdf:~0.7@beta --no-update
   - composer install --no-interaction
 
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"

--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ by default CakePdf expects the wkhtmltopdf binary to be located in /usr/bin/wkht
 DomPdf, Mpdf and Tcpdf can be installed via composer using on of the following commands:
 
 ```
-composer require dompdf/dompdf
+composer require dompdf/dompdf:~0.7@beta
 composer require tecnick.com/tcpdf
 composer require mpdf/mpdf
 ```
+
+Please note that this branch of CakePDF requires at least DomPdf version `0.7`, which is
+currently in beta stage. Once it becomes stable, you should make sure to require the
+stable, non-suffixed version, ie use a constraint like `~0.7`.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Configuration options:
 * engine: Engine to be used (required), or an array of engine config options
   * className: Engine class to use
   * binary: Binary file to use (Only for wkhtmltopdf)
-  * options: Options to pass on to wkhtmltopdf
+  * options: Engine specific options. Currently only for `WkHtmlToPdf`, where the options
+    are passed as CLI arguments, and for `DomPdf`, where the options are passed to the
+    `DomPdf` class constructor.
 * crypto: Crypto engine to be used, or an array of crypto config options
   * className: Crypto class to use
   * binary: Binary file to use

--- a/src/Pdf/Engine/DomPdfEngine.php
+++ b/src/Pdf/Engine/DomPdfEngine.php
@@ -2,6 +2,7 @@
 namespace CakePdf\Pdf\Engine;
 
 use CakePdf\Pdf\CakePdf;
+use Dompdf\Dompdf;
 
 class DomPdfEngine extends AbstractPdfEngine
 {
@@ -14,12 +15,6 @@ class DomPdfEngine extends AbstractPdfEngine
     public function __construct(CakePdf $Pdf)
     {
         parent::__construct($Pdf);
-        if (!defined('DOMPDF_FONT_CACHE')) {
-            define('DOMPDF_FONT_CACHE', TMP);
-        }
-        if (!defined('DOMPDF_TEMP_DIR')) {
-            define('DOMPDF_TEMP_DIR', TMP);
-        }
     }
 
     /**
@@ -29,9 +24,15 @@ class DomPdfEngine extends AbstractPdfEngine
      */
     public function output()
     {
-        $DomPDF = new \DOMPDF();
-        $DomPDF->set_paper($this->_Pdf->pageSize(), $this->_Pdf->orientation());
-        $DomPDF->load_html($this->_Pdf->html());
+        $defaults = [
+            'fontCache' => TMP,
+            'tempDir' => TMP
+        ];
+        $options = (array)$this->config('options') + $defaults;
+
+        $DomPDF = new Dompdf($options);
+        $DomPDF->setPaper($this->_Pdf->pageSize(), $this->_Pdf->orientation());
+        $DomPDF->loadHtml($this->_Pdf->html());
         $DomPDF->render();
         return $DomPDF->output();
     }

--- a/src/Pdf/Engine/DomPdfEngine.php
+++ b/src/Pdf/Engine/DomPdfEngine.php
@@ -8,16 +8,6 @@ class DomPdfEngine extends AbstractPdfEngine
 {
 
     /**
-     * Constructor
-     *
-     * @param CakePdf $Pdf CakePdf instance
-     */
-    public function __construct(CakePdf $Pdf)
-    {
-        parent::__construct($Pdf);
-    }
-
-    /**
      * Generates Pdf from html
      *
      * @return string raw pdf data
@@ -30,10 +20,45 @@ class DomPdfEngine extends AbstractPdfEngine
         ];
         $options = (array)$this->config('options') + $defaults;
 
-        $DomPDF = new Dompdf($options);
+        $DomPDF = $this->_createInstance($options);
         $DomPDF->setPaper($this->_Pdf->pageSize(), $this->_Pdf->orientation());
-        $DomPDF->loadHtml($this->_Pdf->html());
+        $DomPDF = $this->_render($this->_Pdf, $DomPDF);
+        return $this->_output($DomPDF);
+    }
+
+    /**
+     * Creates the Dompdf instance.
+     *
+     * @param array $options The engine options.
+     * @return Dompdf
+     */
+    protected function _createInstance($options)
+    {
+        return new Dompdf($options);
+    }
+
+    /**
+     * Renders the Dompdf instance.
+     *
+     * @param CakePdf $Pdf The CakePdf instance that supplies the content to render.
+     * @param Dompdf $DomPDF The Dompdf instance to render.
+     * @return Dompdf
+     */
+    protected function _render($Pdf, $DomPDF)
+    {
+        $DomPDF->loadHtml($Pdf->html());
         $DomPDF->render();
+        return $DomPDF;
+    }
+
+    /**
+     * Generates the PDF output.
+     *
+     * @param Dompdf $DomPDF The Dompdf instance from which to generate the output from.
+     * @return string
+     */
+    protected function _output($DomPDF)
+    {
         return $DomPDF->output();
     }
 }

--- a/tests/TestCase/Pdf/Engine/DomPdfEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/DomPdfEngineTest.php
@@ -1,0 +1,176 @@
+<?php
+namespace CakePdf\Test\TestCase\Pdf\Engine;
+
+use CakePdf\Pdf\CakePdf;
+use Cake\TestSuite\TestCase;
+use Dompdf\Dompdf;
+
+/**
+ * DomPdfEngineTest class
+ */
+class DomPdfEngineTest extends TestCase
+{
+
+    /**
+     * Tests that the engine receives the expected options.
+     */
+    public function testReceiveOptions()
+    {
+        $engineClass = $this->getMockClass('\CakePdf\Pdf\Engine\DomPdfEngine', ['_createInstance']);
+
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => '\\' . $engineClass,
+                'options' => [
+                    'isJavascriptEnabled' => false,
+                    'isHtml5ParserEnabled' => true
+                ]
+            ]
+        ]);
+
+        $Pdf
+            ->engine()
+            ->expects($this->once())
+            ->method('_createInstance')
+            ->with([
+                'fontCache' => TMP,
+                'tempDir' => TMP,
+                'isJavascriptEnabled' => false,
+                'isHtml5ParserEnabled' => true
+            ])
+            ->will($this->returnCallback(function ($options) {
+                return new Dompdf($options);
+            }));
+
+        $Pdf->engine()->output();
+    }
+
+    /**
+     * Tests that the engine sets the options properly.
+     */
+    public function testSetOptions()
+    {
+        $engineClass = $this->getMockClass('\CakePdf\Pdf\Engine\DomPdfEngine', ['_output']);
+
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => '\\' . $engineClass,
+                'options' => [
+                    'isJavascriptEnabled' => false,
+                    'isHtml5ParserEnabled' => true
+                ]
+            ]
+        ]);
+
+        $Pdf
+            ->engine()
+            ->expects($this->once())
+            ->method('_output')
+            ->will($this->returnCallback(function ($Dompdf) {
+                $Options = $Dompdf->getOptions();
+                $this->assertEquals(TMP, $Options->getFontCache());
+                $this->assertEquals(TMP, $Options->getTempDir());
+                $this->assertFalse($Options->getIsJavascriptEnabled());
+                $this->assertTrue($Options->getIsHtml5ParserEnabled());
+                return $Dompdf->output();
+            }));
+
+        $Pdf->engine()->output();
+    }
+
+    /**
+     * Tests generating actual output.
+     */
+    public function testOutput()
+    {
+        $Pdf = new CakePdf([
+            'engine' => 'CakePdf.Dompdf'
+        ]);
+        $Pdf->html('<foo>bar</foo>');
+
+        $output = $Pdf->engine()->output();
+        $this->assertStringStartsWith('%PDF-1.3', $output);
+        $this->assertStringEndsWith("%%EOF\n", $output);
+    }
+
+    /**
+     * Tests that the engine runs as expected.
+     */
+    public function testControlFlow()
+    {
+        $engineClass = $this->getMockClass('\CakePdf\Pdf\Engine\DomPdfEngine', [
+            '_createInstance',
+            '_render',
+            '_output'
+        ]);
+
+        $Pdf = new CakePdf([
+            'engine' => '\\' . $engineClass
+        ]);
+
+        $DomPDF = new Dompdf();
+
+        $Pdf
+            ->engine()
+            ->expects($this->at(0))
+            ->method('_createInstance')
+            ->willReturn($DomPDF);
+
+        $Pdf
+            ->engine()
+            ->expects($this->at(1))
+            ->method('_render')
+            ->with($Pdf, $DomPDF)
+            ->willReturn($DomPDF);
+
+        $Pdf
+            ->engine()
+            ->expects($this->at(2))
+            ->method('_output')
+            ->with($DomPDF);
+
+        $Pdf->engine()->output();
+    }
+
+    /**
+     * Tests that the Dompdf instance is being processed as expected.
+     */
+    public function testDompdfControlFlow()
+    {
+        $engineClass = $this->getMockClass('\CakePdf\Pdf\Engine\DomPdfEngine', ['_createInstance']);
+
+        $Pdf = new CakePdf([
+            'engine' => '\\' . $engineClass
+        ]);
+
+        $Pdf
+            ->engine()
+            ->expects($this->once())
+            ->method('_createInstance')
+            ->will($this->returnCallback(function ($options) {
+                $Dompdf = $this->getMock(
+                    '\Dompdf\Dompdf',
+                    ['setPaper', 'loadHtml', 'render', 'output'],
+                    [$options]
+                );
+                $Dompdf
+                    ->expects($this->at(0))
+                    ->method('setPaper')
+                    ->with('A4', 'portrait');
+                $Dompdf
+                    ->expects($this->at(1))
+                    ->method('loadHtml')
+                    ->with(null);
+                $Dompdf
+                    ->expects($this->at(2))
+                    ->method('render');
+                $Dompdf
+                    ->expects($this->at(3))
+                    ->method('output');
+
+                return $Dompdf;
+            }));
+
+        $Pdf->engine()->output();
+    }
+}

--- a/tests/TestCase/Pdf/Engine/DomPdfEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/DomPdfEngineTest.php
@@ -110,26 +110,22 @@ class DomPdfEngineTest extends TestCase
 
         $DomPDF = new Dompdf();
 
-        $Pdf
-            ->engine()
+        $Engine = $Pdf->engine();
+        $Engine
             ->expects($this->at(0))
             ->method('_createInstance')
             ->willReturn($DomPDF);
-
-        $Pdf
-            ->engine()
+        $Engine
             ->expects($this->at(1))
             ->method('_render')
             ->with($Pdf, $DomPDF)
             ->willReturn($DomPDF);
-
-        $Pdf
-            ->engine()
+        $Engine
             ->expects($this->at(2))
             ->method('_output')
             ->with($DomPDF);
 
-        $Pdf->engine()->output();
+        $Engine->output();
     }
 
     /**


### PR DESCRIPTION
Recently CakePdf switched to [supporting the new 0.7 branch of DomPdf](https://github.com/FriendsOfCake/CakePdf/commit/d50c0e7a83e8db567384c24dae0437741bd5a8f2), which not only uses namespaces, but also changed quite a few internals, one being that pretty much all the options constants are gone, and the `DomPdf` class now needs to be explicitly fed with options.

The new branch is still in beta, so I'm not sure whether CakePdf should jump on supporting/requiring it yet, but if it should, then it would be good if it would support options, which this PR aims to implement.

Currently there seems to be no option for the orientation, so for now page size and orientation is still set via `DomPdf::setPaper()`. There's probobaly going to be some change around this, see https://github.com/dompdf/dompdf/blob/v0.7.0-beta3/src/Dompdf.php#L740, so one should keep an eye on that.

ps. I can add tests later on in case this PR is being considered to be merged.