### PR TITLE
Remove Dompdf 0.7 beta notes and usage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
   - sudo touch /usr/bin/latexpdf && sudo chmod +x /usr/bin/latexpdf
 
   - composer self-update
-  - composer require dompdf/dompdf:~0.7@beta --no-update
+  - composer require dompdf/dompdf --no-update
   - composer install --no-interaction
 
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer:dev-master; fi"

--- a/README.md
+++ b/README.md
@@ -40,14 +40,10 @@ use `C:/Progra~1/wkhtmltopdf/bin/wkhtmltopdf.exe`
 DomPdf, Mpdf and Tcpdf can be installed via composer using on of the following commands:
 
 ```
-composer require dompdf/dompdf:~0.7@beta
+composer require dompdf/dompdf
 composer require tecnick.com/tcpdf
 composer require mpdf/mpdf
 ```
-
-Please note that this branch of CakePDF requires at least DomPdf version `0.7`, which is
-currently in beta stage. Once it becomes stable, you should make sure to require the
-stable, non-suffixed version, ie use a constraint like `~0.7`.
 
 ## Setup
 


### PR DESCRIPTION
0.7 has been released as stable, the notes and the beta branch usage aren't required anymore.