### PR TITLE
TCPDF engine improvement

### DIFF
--- a/src/Pdf/Engine/TcpdfEngine.php
+++ b/src/Pdf/Engine/TcpdfEngine.php
@@ -14,6 +14,9 @@ class TcpdfEngine extends AbstractPdfEngine
         //TCPDF often produces a whole bunch of errors, although there is a pdf created when debug = 0
         //Configure::write('debug', 0);
         $TCPDF = new \TCPDF($this->_Pdf->orientation(), 'mm', $this->_Pdf->pageSize());
+        $TCPDF->setPrintFooter(false);
+        $TCPDF->setPrintHeader(false);
+        $TCPDF->setFont('freesans');
         $TCPDF->AddPage();
         $TCPDF->writeHTML($this->_Pdf->html());
 


### PR DESCRIPTION
I added this lines to the engine setup:
```php
        $TCPDF->setPrintFooter(false);
        $TCPDF->setPrintHeader(false);
        $TCPDF->setFont('freesans');
```
for special charachters (Ç, ç, Ğ, ğ, Ş, .....) ```$TCPDF->setFont('freesans');``` solved my problem
In addition I disabled the footer and header printing because we don't have them for now