### PR TITLE
Better error handling for wkhtmltopdf.

### DIFF
--- a/src/Pdf/Engine/WkHtmlToPdfEngine.php
+++ b/src/Pdf/Engine/WkHtmlToPdfEngine.php
@@ -33,18 +33,20 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
      */
     public function output()
     {
-        $content = $this->_exec($this->_getCommand(), $this->_Pdf->html());
+        $command = $this->_getCommand();
+        $content = $this->_exec($command, $this->_Pdf->html());
 
-        if (strpos(mb_strtolower($content['stderr']), 'error')) {
-            throw new Exception("System error <pre>" . $content['stderr'] . "</pre>");
+        if ((int)$content['return'] !== 0 || !empty($content['stderr'])) {
+            throw new Exception(sprintf(
+                'System error "%s" when executing command "%s". ' .
+                'Try using the binary provided on http://wkhtmltopdf.org/downloads.html',
+                $content['stderr'],
+                $command
+            ));
         }
 
         if (mb_strlen($content['stdout'], $this->_Pdf->encoding()) === 0) {
             throw new Exception("WKHTMLTOPDF didn't return any data");
-        }
-
-        if ((int)$content['return'] !== 0 && !empty($content['stderr'])) {
-            throw new Exception("Shell error, return code: " . (int)$content['return']);
         }
 
         return $content['stdout'];


### PR DESCRIPTION
For e.g. on ubuntu 16.04 with wkhtmltopdf install from distro packages you will exception with message:

`System error "The switch --print-media-type, is not support using unpatched qt, and will be ignored.QXcbConnection: Could not connect to display Aborted " when executing command "/usr/bin/wkhtmltopdf --quiet --print-media-type --orientation 'portrait' --page-size 'A4' --encoding 'UTF-8' - -".Try using the binary provided on http://wkhtmltopdf.org/downloads.html`