### PR TITLE
Support mpdf 7.0 with support for PHP 7.x

### DIFF
--- a/src/Pdf/Engine/MpdfEngine.php
+++ b/src/Pdf/Engine/MpdfEngine.php
@@ -14,9 +14,21 @@ class MpdfEngine extends AbstractPdfEngine
         //mPDF often produces a whole bunch of errors, although there is a pdf created when debug = 0
         //Configure::write('debug', 0);
         $orientation = $this->_Pdf->orientation() == 'landscape' ? 'L' : 'P';
-        $MPDF = new \mPDF($this->_Pdf->encoding(), $this->_Pdf->pageSize() . '-' . $orientation);
-        $MPDF->writeHTML($this->_Pdf->html());
 
-        return $MPDF->Output('', 'S');
+        if (class_exists('\mpdf')) {
+            //Mpdf < 7.0
+            $mpdf = new \mPDF($this->_Pdf->encoding(), $this->_Pdf->pageSize() . '-' . $orientation);
+        } else {
+            //Mpdf >= 7.0
+            $mpdf = new \Mpdf\Mpdf([
+                'mode' => $this->_Pdf->encoding(),
+                'format' => $this->_Pdf->pageSize(),
+                'orientation' => $orientation,
+            ]);
+        }
+
+        $mpdf->writeHtml($this->_Pdf->html());
+
+        return $mpdf->Output('', 'S');
     }
 }


### PR DESCRIPTION
mpdf 7.0 is in beta2 currently (since march 2017) -
 release: https://github.com/mpdf/mpdf/releases/tag/v7.0.0-beta2

They have put the mpdf class in the `\Mpdf` namespace and renamed it from `mPDF` to `Mpdf` so I've adjusted the `MpdfEngine` to reflect the changes without breaking functionality with mpdf 6.x

- [ ] Add "options" config to pdf config which can be preserved and passed to constructor as in dompdf
- [ ] Add tests (check DomPdf tests for reference)