### PR TITLE
Fix for the cases where controller throws exception and the page shal…

### DIFF
--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -65,7 +65,7 @@ class PdfView extends View
         );
 
         $response->type('pdf');
-        if (isset($viewOptions['name']) && $viewOptions['name'] == 'Error') {
+        if (isset($viewOptions['templatePath']) && $viewOptions['templatePath'] == 'Error') {
             $this->subDir = null;
             $this->layoutPath = null;
             $response->type('html');

--- a/tests/TestCase/View/PdfViewTest.php
+++ b/tests/TestCase/View/PdfViewTest.php
@@ -56,7 +56,6 @@ class PdfViewTest extends TestCase
             'engine' => '\\' . __NAMESPACE__ . '\PdfTestEngine'
         ]);
 
-
         $request = new Request();
         $response = new Response();
         $this->View = new PdfView($request, $response);
@@ -104,23 +103,20 @@ class PdfViewTest extends TestCase
         $this->assertEquals('', $result);
     }
 
-
     /**
-     * Test rendering an Error template, which should
-     * default to standard layout
+     * Test rendering an Error template, which should  default to standard layout
      *
-    **/
+     */
     public function testRenderErrorTemplate()
     {
         $request = new Request();
         $response = new Response();
         $this->View = new PdfView($request, $response, null, [ 'templatePath' => 'Error' ]);
 
-        $this->assertTrue( $this->View->subDir === null );
-        $this->assertTrue( $this->View->layoutPath === null );
+        $this->assertTrue($this->View->subDir === null);
+        $this->assertTrue($this->View->layoutPath === null);
 
         $result = $this->View->response->type();
         $this->assertEquals('text/html', $result);
-
     }
 }

--- a/tests/TestCase/View/PdfViewTest.php
+++ b/tests/TestCase/View/PdfViewTest.php
@@ -103,4 +103,24 @@ class PdfViewTest extends TestCase
         $result = $this->View->render('empty', 'empty');
         $this->assertEquals('', $result);
     }
+
+
+    /**
+     * Test rendering an Error template, which should
+     * default to standard layout
+     *
+    **/
+    public function testRenderErrorTemplate()
+    {
+        $request = new Request();
+        $response = new Response();
+        $this->View = new PdfView($request, $response, null, [ 'templatePath' => 'Error' ]);
+
+        $this->assertTrue( $this->View->subDir === null );
+        $this->assertTrue( $this->View->layoutPath === null );
+
+        $result = $this->View->response->type();
+        $this->assertEquals('text/html', $result);
+
+    }
 }


### PR DESCRIPTION
When throwing exception in controller, which is rendering using CakePdf view, I'm getting pdf binary data printed in the browser window?!

I noticed that CakePdf has special condition in its constructor to render using default layout/view in case when it is rendered by Error controller. Anyway that is my understanding.

This case is never happening in my app using CakePHP 3.3.x. 
The exception renderer class uses viewOption.name equals to the controller, which thrown exception, rather than the Error controller. 

I noticed that the viewOption.templatePath always equals to 'Error', so I suggested using this option to recognize the case of exception/error.