### PR TITLE
Fix getCommand options not taking values when equals to zero

### DIFF
--- a/src/Pdf/Engine/WkHtmlToPdfEngine.php
+++ b/src/Pdf/Engine/WkHtmlToPdfEngine.php
@@ -131,7 +131,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
         }
 
         foreach ($options as $key => $value) {
-            if (empty($value)) {
+            if (!isset($value) || !== false) {
                 continue;
             } elseif (is_array($value)) {
                 foreach ($value as $k => $v) {


### PR DESCRIPTION
For WkhtmlToPdfEngine, we have to set engine specific options for margin and if we set 0 as value it is skipped because empty function returning false when value is equal to zero. 

