### PR TITLE
add footer and header to array options

### DIFF
--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -259,6 +259,8 @@ class CakePdf
             'cache',
             'delay',
             'windowStatus',
+            'header',
+            'footer'
         ];
         foreach ($options as $option) {
             if (isset($config[$option])) {


### PR DESCRIPTION
This resolve the footer and header options:

```php
$this->viewBuilder()->options([
                'pdfConfig' => [
                    'orientation' => 'portrait',
                    'filename' => 'Invoice_' . $id,
                    //header use the same options
                    'footer' => [
                        'left' => 'hello',
                        'center' => 'world',
                        'rigth' => '?'
                    ]
                ]
            ]);
```
I had to put margin bottom more than 5 to being able to watch it.
