### PR TITLE
Ensure "extract" with EXTR_IF_EXISTS works correctly

### DIFF
--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -469,6 +469,7 @@ class CakePdf
         }
 
         if (is_array($left)) {
+            $left = $left + ['left' => null];
             extract($left, EXTR_IF_EXISTS);
         }
 
@@ -492,6 +493,7 @@ class CakePdf
         }
 
         if (is_array($left)) {
+            $left = $left + ['left' => null];
             extract($left, EXTR_IF_EXISTS);
         }
 
@@ -541,6 +543,7 @@ class CakePdf
         }
 
         if (is_array($bottom)) {
+            $bottom = $bottom + ['bottom' => null];
             extract($bottom, EXTR_IF_EXISTS);
         }
 


### PR DESCRIPTION
The EXTR_IF_EXISTS on the methods `margin()`, `header()` and  `footer()` when an array is given without "bottom" and "left" keys.

The error can be reproduced with this example:

            $this->viewBuilder()->setOptions([
                'pdfConfig' => [
                    'margin' => [
                        'top' => 30,
                        // 'bottom' => 25,
                        'left' => 20,
                        'right' => 20,
                    ],
                    'header' => [
                        // 'left' => 'A',
                        'center' => 'B',
                        'right' => 'C'
                    ],
                    'footer' => [
                        // 'left' => 'A',
                        'center' => 'B',
                        'right' => 'C',
                    ]
                ]
            ]);

I'm using `WkHtmlToPdfEngine` and it output these errors:

```
Notice (8): Array to string conversion [ROOT/vendor/friendsofcake/cakepdf/src/Pdf/Engine/WkHtmlToPdfEngine.php, line 123]
Warning (2): addslashes() expects parameter 1 to be string, array given [ROOT/vendor/friendsofcake/cakepdf/src/Pdf/Engine/WkHtmlToPdfEngine.php, line 150]
Warning (2): addslashes() expects parameter 1 to be string, array given [ROOT/vendor/friendsofcake/cakepdf/src/Pdf/Engine/WkHtmlToPdfEngine.php, line 157]
```
I'll write some aditional tests latter, but this week i'm really busy.