### PR TITLE
dompdf from composer compatibility for 1.0 branch

### DIFF
--- a/Pdf/Engine/DomPdfEngine.php
+++ b/Pdf/Engine/DomPdfEngine.php
@@ -1,6 +1,9 @@
 <?php
+require APP . 'Vendor/autoload.php';
+
+use Dompdf\Dompdf;
+
 App::uses('AbstractPdfEngine', 'CakePdf.Pdf/Engine');
-App::uses('Multibyte', 'I18n');
 
 class DomPdfEngine extends AbstractPdfEngine {
 
@@ -11,17 +14,6 @@ class DomPdfEngine extends AbstractPdfEngine {
  */
 	public function __construct(CakePdf $Pdf) {
 		parent::__construct($Pdf);
-		if (!defined('DOMPDF_FONT_CACHE')) {
-			define('DOMPDF_FONT_CACHE', TMP);
-		}
-		if (!defined('DOMPDF_TEMP_DIR')) {
-			define('DOMPDF_TEMP_DIR', TMP);
-		}
-
-		if (App::import('Vendor', 'DomPDF', array('file' => 'dompdf' . DS . 'dompdf' . DS . 'dompdf_config.inc.php'))) {
-			return;
-		}
-		App::import('Vendor', 'CakePdf.DomPDF', array('file' => 'dompdf' . DS . 'dompdf_config.inc.php'));
 	}
 
 /**
@@ -30,7 +22,10 @@ class DomPdfEngine extends AbstractPdfEngine {
  * @return string raw pdf data
  */
 	public function output() {
-		$DomPDF = new DOMPDF();
+		$DomPDF = new Dompdf();
+		foreach ($this->config('options') as $option => $value) {
+			$DomPDF->set_option($option, $value);
+		}
 		$DomPDF->set_paper($this->_Pdf->pageSize(), $this->_Pdf->orientation());
 		$DomPDF->load_html($this->_Pdf->html());
 		$DomPDF->render();


### PR DESCRIPTION
* avoid the dompdf included in 1.0.3 as it is too old and screws utf-8 glyphs that the version available from composer is able to process ok (0.8.x)

* honor the passthrough options as well