### PR TITLE
Fix problem related to session-handling in PHP 7.2

### DIFF
--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -7,6 +7,7 @@ use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use Cake\Filesystem\File;
 use Cake\Http\ServerRequestFactory;
+use Cake\Routing\Router;
 
 class CakePdf
 {
@@ -953,8 +954,13 @@ class CakePdf
             $viewOptions[$var] = $this->{$prop};
         }
 
+        $request = Router::getRequest(true);
+        if (!$request) {
+            $request = ServerRequestFactory::fromGlobals();
+        }
+
         $View = new $viewClass(
-            ServerRequestFactory::fromGlobals(),
+            $request,
             null,
             null,
             $viewOptions


### PR DESCRIPTION
We were getting the following error trace (printed as output at the beginning of the generated PDF file) on PHP 7.2:

```
<pre class="cake-error"><a href="javascript:void(0);" onclick="document.getElementById('cakeErr5bd6fbb1b2741-trace').style.display = (document.getElementById('cakeErr5bd6fbb1b2741-trace').style.display == 'none' ? '' : 'none');"><b>Warning</b> (2)</a>: session_set_save_handler(): Cannot change save handler when session is active [<b>CORE/src/Http/Session.php</b>, line <b>294</b>]<div id="cakeErr5bd6fbb1b2741-trace" class="cake-stack-trace" style="display: none;"><a href="javascript:void(0);" onclick="document.getElementById('cakeErr5bd6fbb1b2741-code').style.display = (document.getElementById('cakeErr5bd6fbb1b2741-code').style.display == 'none' ? '' : 'none')">Code</a> <a href="javascript:void(0);" onclick="document.getElementById('cakeErr5bd6fbb1b2741-context').style.display = (document.getElementById('cakeErr5bd6fbb1b2741-context').style.display == 'none' ? '' : 'none')">Context</a><pre id="cakeErr5bd6fbb1b2741-code" class="cake-code-dump" style="display: none;"><code><span style="color: #000000"><span style="color: #0000BB"></span></span></code>
<span class="code-highlight"><code><span style="color: #000000"><span style="color: #0000BB">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span><span style="color: #007700">return&nbsp;</span><span style="color: #0000BB">parent</span><span style="color: #007700">::</span><span style="color: #0000BB">handleError</span><span style="color: #007700">(</span><span style="color: #0000BB">$code</span><span style="color: #007700">,&nbsp;</span><span style="color: #0000BB">$description</span><span style="color: #007700">,&nbsp;</span><span style="color: #0000BB">$file</span><span style="color: #007700">,&nbsp;</span><span style="color: #0000BB">$line</span><span style="color: #007700">,&nbsp;</span><span style="color: #0000BB">$context</span><span style="color: #007700">);</span></span></code></span>
<code><span style="color: #000000"><span style="color: #0000BB">&nbsp;&nbsp;&nbsp;&nbsp;</span><span style="color: #007700">}</span></span></code></pre><pre id="cakeErr5bd6fbb1b2741-context" class="cake-context" style="display: none;">$handler = object(Cake\Http\Session\DatabaseSession) {
	[protected] _table =&gt; object(uAfrica\Model\Table\CakeSessionsTable) {}
	[protected] _timeout =&gt; (int) 259200
	[protected] _tableLocator =&gt; object(Cake\ORM\Locator\TableLocator) {}
}</pre><pre class="stack-trace">uAfrica\Error\ErrorHandler::handleError() - APP/Error/NewRelicErrorHandlerTrait.php, line 37
Cake\Core\BasePlugin::{closure}() - ROOT/vendor/cakephp/debug_kit/config/bootstrap.php, line 42
session_set_save_handler - [internal], line ??
Cake\Http\Session::setEngine() - CORE/src/Http/Session.php, line 294
Cake\Http\Session::engine() - CORE/src/Http/Session.php, line 282
Cake\Http\Session::__construct() - CORE/src/Http/Session.php, line 228
Cake\Http\Session::create() - CORE/src/Http/Session.php, line 129
Cake\Http\ServerRequestFactory::fromGlobals() - CORE/src/Http/ServerRequestFactory.php, line 46
CakePdf\Pdf\CakePdf::_render() - ROOT/vendor/friendsofcake/cakepdf/src/Pdf/CakePdf.php, line 957
CakePdf\Pdf\CakePdf::output() - ROOT/vendor/friendsofcake/cakepdf/src/Pdf/CakePdf.php, line 285
...
```

This appears to be related to changes in session-handling in PHP 7.2, which now apparently causes warnings to be thrown instead of being ignored silently (as was the case before 7.2).  This PR attempts to fix the problem.