### PR TITLE
PDFreactor Engine

### DIFF
--- a/src/Pdf/Engine/PdfReactorEngine.php
+++ b/src/Pdf/Engine/PdfReactorEngine.php
@@ -1,0 +1,121 @@
+<?php
+namespace CakePdf\Pdf\Engine;
+
+use CakePdf\Pdf\CakePdf;
+use Cake\Core\App;
+use Cake\Core\Exception\Exception;
+
+/**
+ *
+ * @author jmischer
+ * 
+ */
+class PdfReactorEngine extends AbstractPdfEngine {
+	/**
+	 * 
+	 * @param CakePdf $Pdf
+	 */
+	public function __construct(CakePdf $Pdf) {
+		parent::__construct($Pdf);
+	}
+	
+	/**
+	 * Generates Pdf from html.
+	 *
+	 * @return string raw pdf data
+	 */
+	public function output() {
+		// Get client config
+		$client = $this->getConfig('client',
+				'\com\realobjects\pdfreactor\webservice\client\PDFreactor');
+		
+		// Get pdf reactor
+		$pdf_reactor = $this->createInstance($client);
+		
+		// Get engine options
+		$options = $this->getConfig('options', []);
+		
+		// Create pdf reactor render configuration
+		$config = $this->createConfig($options, $this->_Pdf);
+		
+		// Return output
+		return $this->_output($pdf_reactor, $config);
+	}
+	
+	/**
+	 * Creates the pdf reactor instance.
+	 * 
+	 * @param $options
+	 * @throws Exception
+	 * @return object
+	 */
+	protected function createInstance($options) {
+		// Extract service url and client class name from client config if array
+		$service_url = null;
+		if (is_array($options)) {
+			if (isset($options['serviceUrl'])) {
+				$service_url = $options['serviceUrl'];
+			}
+			$client = $options['className'];
+		} else {
+			$client = $options;
+		}
+		
+		// Check client is an object, otherwise try create instance it
+		if (is_object($client)) {
+			$pdf_reactor = $client;
+		} else {
+			// Get client class name
+			$client_class_name = App::className($client);
+			if (!class_exists($client_class_name)) {
+				throw new Exception(__d('cake_pdf',
+						'PDFreactor: Client "{0}" not found', $client));
+			}
+			
+			// Initialize pdf reactor client instance
+			$pdf_reactor = new $client_class_name($service_url);
+		}
+		if (!method_exists($pdf_reactor, 'convertAsBinary')) {
+			throw new Exception(__d('cake_pdf',
+					'PDFreactor: Missing method "convertAsBinary" for client "{0}"', 
+					get_class($pdf_reactor)));
+		}
+		return $pdf_reactor;
+	}
+	
+	/**
+	 * Create the pdf reactor configuration for rendering.
+	 *
+	 * @param array $options
+	 * @param CakePdf $cakepdf
+	 */
+	protected function createConfig(array $options, CakePdf $cakepdf) {
+		// Set config
+		$config = $options;
+		
+		// Set document to render
+		$config['document'] = $cakepdf->html() ?: '<html />';
+		
+		// Return config
+		return $config;
+	}
+	
+	/**
+	 * 
+	 * @param object $pdfReactor
+	 * @param \CakePdf\Pdf\CakePdf $cakepdf
+	 * @throws Exception
+	 * @return string
+	 */
+	protected function _output($pdfReactor, $config) {
+		try {
+			// Convert as binary and return result
+			return $pdfReactor->convertAsBinary($config);
+		} catch (\Exception $ex) {
+			throw new Exception(
+					__d('cake_pdf', 'PDFreactor: {0}', $ex->getMessage()),
+					$ex->getCode(), $ex);
+		}
+	}
+}
+

--- a/src/Pdf/Engine/PdfReactorEngine.php
+++ b/src/Pdf/Engine/PdfReactorEngine.php
@@ -29,7 +29,7 @@ class PdfReactorEngine extends AbstractPdfEngine {
 		$client = $this->getConfig('client',
 				'\com\realobjects\pdfreactor\webservice\client\PDFreactor');
 		
-		// Get pdf reactor
+		// Create pdf reactor instance
 		$pdf_reactor = $this->createInstance($client);
 		
 		// Get engine options
@@ -45,42 +45,39 @@ class PdfReactorEngine extends AbstractPdfEngine {
 	/**
 	 * Creates the pdf reactor instance.
 	 * 
-	 * @param $options
+	 * @param mixed $client	The client configuration, class name or instance
 	 * @throws Exception
 	 * @return object
 	 */
-	protected function createInstance($options) {
-		// Extract service url and client class name from client config if array
-		$service_url = null;
-		if (is_array($options)) {
-			if (isset($options['serviceUrl'])) {
-				$service_url = $options['serviceUrl'];
+	protected function createInstance($client) {
+		// Get client instance from client config
+		if (!is_object($client)) {
+			$service_url = null;
+			if (is_array($client)) {
+				if (isset($client['serviceUrl'])) {
+					$service_url = $client['serviceUrl'];
+				}
+				$client = $client['className'];
 			}
-			$client = $options['className'];
-		} else {
-			$client = $options;
-		}
-		
-		// Check client is an object, otherwise try create instance it
-		if (is_object($client)) {
-			$pdf_reactor = $client;
-		} else {
-			// Get client class name
+			
+			// Get class and create instance
 			$client_class_name = App::className($client);
 			if (!class_exists($client_class_name)) {
 				throw new Exception(__d('cake_pdf',
 						'PDFreactor: Client "{0}" not found', $client));
 			}
-			
-			// Initialize pdf reactor client instance
-			$pdf_reactor = new $client_class_name($service_url);
+			$client = new $client_class_name($service_url);
 		}
-		if (!method_exists($pdf_reactor, 'convertAsBinary')) {
+		
+		// Check client methode "convertAsBinary" exists
+		if (!method_exists($client, 'convertAsBinary')) {
 			throw new Exception(__d('cake_pdf',
 					'PDFreactor: Missing method "convertAsBinary" for client "{0}"', 
-					get_class($pdf_reactor)));
+					get_class($client)));
 		}
-		return $pdf_reactor;
+		
+		// Retur instance
+		return $client;
 	}
 	
 	/**

--- a/tests/TestCase/Pdf/Engine/PdfReactorEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/PdfReactorEngineTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace CakePdf\Test\TestCase\Pdf\Engine;
+
+use Cake\TestSuite\TestCase;
+use CakePdf\Pdf\CakePdf;
+use CakePdf\Pdf\Engine\PdfReactorEngine;
+
+/**
+ *
+ * @author jmischer
+ *        
+ */
+class PdfReactorEngineTest extends TestCase {
+	/**
+	 * 
+	 * @var \PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $pdfReactorMock;
+	
+	/**
+	 * 
+	 * {@inheritDoc}
+	 * @see \Cake\TestSuite\TestCase::setUp()
+	 */
+	public function setUp() {
+		parent::setUp();
+		
+		$this->pdfReactorMock = $this->getMockBuilder('PDFreactor')
+			->setMethods(['convertAsBinary'])
+			->getMock();
+		$this->pdfReactorMock->expects($this->once())
+			->method('convertAsBinary')
+			->will($this->returnCallback(function() {
+				return "%PDF-1.4 MOCK ... %%EOF\n";
+			}));
+	}
+	
+	/**
+	 * 
+	 * {@inheritDoc}
+	 * @see \Cake\TestSuite\TestCase::tearDown()
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		unset($this->pdfReactorMock);
+	}
+	
+	/**
+	 * Test output of client gets called.
+	 */
+	public function testOutput() {
+		$Pdf = new CakePdf([
+			'engine' => [
+				'className' => 'CakePdf.PdfReactor',
+				'client' => $this->pdfReactorMock
+			]
+		]);
+		$Pdf->html('<foo>bar</foo>');
+		$output = $Pdf->engine()->output();
+		$this->assertStringStartsWith('%PDF-1.4 MOCK', $output);
+		$this->assertStringEndsWith("%%EOF\n", $output);
+	}
+	
+	/**
+	 * Test createInstance gets passed the client config.
+	 */
+	public function testCreateInstance() {
+		// Mock PdfReactorEngine
+		$engineClass = $this->getMockClass(PdfReactorEngine::class, ['createInstance']);
+		
+		// Initialize client configuration
+		$client_config = [
+			'className' => '\PDFreactor',
+			'serviceUrl' => 'http://localhost:9423/service/rest',
+		];
+		
+		$cakePdf = new CakePdf([
+			'engine' => [
+				'className' => '\\' . $engineClass,
+				'client' => $client_config
+			],
+		]);
+		
+		// Get the mocked engine from CakePdf instance
+		$mock_engine = $cakePdf->engine();
+		$mock_engine->expects($this->once())
+			->method('createInstance')
+			->will($this->returnCallback(function ($options) use ($client_config) {
+				$this->assertEquals($options, $client_config);
+				return $this->pdfReactorMock;
+			}));
+		$mock_engine->output();
+	}
+}
+


### PR DESCRIPTION
I needed to use **PDFreactor** so I had to create a PdfEngine for it. Maybe its worth including it.

This engine is not affiliated with RealObjects (realobjects.com) or PDFreactor (pdfreactor.com).

Load `PDFreactor.class.php` Web Service client.
In `config/bootstrap.php` I added:
``` php
require_once '/opt/PDFreactor/wrappers/php/lib/PDFreactor.class.php';
```

Configuration `config/cakepdf.php`
``` php
return [
    'CakePdf' => [
        'engine' => [
            'className' => 'PdfReactor.PdfReactor',
            'client' => [
                'className' => '\com\realobjects\pdfreactor\webservice\client\PDFreactor',
                'serviceUrl' => 'http://localhost:9423/service/rest',
            ],
            'options' => [
                // PDFreactor configuration ...
            ]
        ],
        'download' => false
    ]
];
```

