### PR TITLE
Check if directory exists before write to avoid mkdir warning

### DIFF
--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -347,7 +347,7 @@ class CakePdf
             return (bool)file_put_contents($destination, $output);
         }
 
-        if (!$fileInfo->isFile()) {
+        if (!$fileInfo->isFile() && !$fileInfo->getPathInfo()->getRealPath()) {
             mkdir($fileInfo->getPath(), 0777, true);
         }
 


### PR DESCRIPTION
Check if the provided path exists before trying to create it to avoid a ```mkdir(): File exists``` warning.

I don't know if it's the best solution, but it solves the warning issue.