### PR TITLE
Allow using command beyond binary on WkHtmlToPdf Engine

### DIFF
--- a/src/Pdf/Engine/WkHtmlToPdfEngine.php
+++ b/src/Pdf/Engine/WkHtmlToPdfEngine.php
@@ -106,7 +106,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
         if ($binary) {
             $this->_binary = $binary;
         }
-        if (!is_executable($this->_binary)) {
+        if (!shell_exec("which {$this->_binary}")) {
             throw new Exception(sprintf('wkhtmltopdf binary is not found or not executable: %s', $this->_binary));
         }
 

--- a/src/Pdf/Engine/WkHtmlToPdfEngine.php
+++ b/src/Pdf/Engine/WkHtmlToPdfEngine.php
@@ -106,7 +106,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
         if ($binary) {
             $this->_binary = $binary;
         }
-        if (!shell_exec("which {$this->_binary}")) {
+        if (!shell_exec("which " . escapeshellarg($this->_binary))) {
             throw new Exception(sprintf('wkhtmltopdf binary is not found or not executable: %s', $this->_binary));
         }
 


### PR DESCRIPTION
I had problem when try using binary config  **wkhtmltopdf**

```
Configure::write('CakePdf', [
    'engine' => ['className' => 'CakePdf.WkHtmlToPdf', 'binary' => 'wkhtmltopdf'],
]);
```
![Screenshot](https://nimbusweb.me/box/attachment/3799045/rar1vii70ch3ievla5lg/DB7Su6aK71lpBfaC/screenshot-172.17.0.4-2020.01.29-19_41_17.png)

Would be great can use command beyond binary.

