### PR TITLE
CakePHP 5 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
-        tools: cs2pr, vimeo/psalm:5.15, phpstan:1.9
+        tools: cs2pr, vimeo/psalm:5.15, phpstan:1.10
 
     - name: Composer Install
       run: composer install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
-        tools: cs2pr, vimeo/psalm:5.15, phpstan:1.8
+        tools: cs2pr, vimeo/psalm:5.15, phpstan:1.9
 
     - name: Composer Install
       run: composer install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['8.1', '8.2']
         prefer-lowest: ['']
-        include:
-          - php-version: '7.2'
-            prefer-lowest: 'prefer-lowest'
 
     steps:
     - uses: actions/checkout@v3
@@ -51,14 +48,10 @@ jobs:
 
     - name: Run PHPUnit
       run: |
-        if [[ ${{ matrix.php-version }} == '7.4' ]]; then
-          vendor/bin/phpunit --verbose --coverage-clover=coverage.xml
-        else
-          vendor/bin/phpunit
-        fi
+        vendor/bin/phpunit
 
     - name: Code Coverage Report
-      if: matrix.php-version == '7.4'
+      if: matrix.php-version == '8.1'
       uses: codecov/codecov-action@v3
 
   cs-stan:
@@ -71,7 +64,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
         tools: cs2pr, vimeo/psalm:4.26, phpstan:1.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
-        tools: cs2pr, vimeo/psalm:4.26, phpstan:1.8
+        tools: cs2pr, vimeo/psalm:5.15, phpstan:1.8
 
     - name: Composer Install
       run: composer install

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "homepage": "http://github.com/friendsofcake/CakePdf",
     "license": "MIT",
     "require": {
-        "cakephp/cakephp": "^4.0"
+        "cakephp/cakephp": "^4.0 || ^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.5.0 || ^9.3",
+        "phpunit/phpunit": "~8.5.0 || ^9.3 || ^10.3",
         "dompdf/dompdf": "^2.0",
         "mpdf/mpdf": "^8.0.4",
         "tecnickcom/tcpdf": "^6.3",

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "homepage": "http://github.com/friendsofcake/CakePdf",
     "license": "MIT",
     "require": {
-        "cakephp/cakephp": "^4.0 || ^5.0"
+        "cakephp/cakephp": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.5.0 || ^9.3 || ^10.3",
+        "phpunit/phpunit": "^10.3",
         "dompdf/dompdf": "^2.0",
         "mpdf/mpdf": "^8.0.4",
         "tecnickcom/tcpdf": "^6.3",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,16 +1,4 @@
 <?php
 declare(strict_types=1);
 
-use Cake\Event\Event;
-use Cake\Event\EventManager;
 
-EventManager::instance()
-    ->on(
-        'Controller.initialize',
-        function (Event $event) {
-            $controller = $event->getSubject();
-            if ($controller->components()->has('RequestHandler')) {
-                $controller->RequestHandler->setConfig('viewClassMap.pdf', 'CakePdf.Pdf');
-            }
-        }
-    );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,14 @@
-<phpunit
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="./tests/bootstrap.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
->
-
-    <testsuites>
-        <testsuite name="CakePdf Plugin Tests">
-            <directory>./tests/TestCase</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src/</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="./tests/bootstrap.php" colors="true" processIsolation="false" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
+  <testsuites>
+    <testsuite name="CakePdf Plugin Tests">
+      <directory>./tests/TestCase</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -357,7 +357,7 @@ class CakePdf
     /**
      * Load PdfEngine
      *
-     * @param ?string|array $name Classname of pdf engine without `Engine` suffix. For example `CakePdf.DomPdf`
+     * @param string|array|null $name Classname of pdf engine without `Engine` suffix. For example `CakePdf.DomPdf`
      * @throws \Cake\Core\Exception\CakeException
      * @return \CakePdf\Pdf\Engine\AbstractPdfEngine|null
      */

--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -319,7 +319,7 @@ class CakePdf
      * @param null|string $html Html to set
      * @return mixed
      */
-    public function html(?string $html = null)
+    public function html(?string $html = null): mixed
     {
         if ($html === null) {
             return $this->_html;
@@ -357,11 +357,11 @@ class CakePdf
     /**
      * Load PdfEngine
      *
-     * @param string|array $name Classname of pdf engine without `Engine` suffix. For example `CakePdf.DomPdf`
+     * @param ?string|array $name Classname of pdf engine without `Engine` suffix. For example `CakePdf.DomPdf`
      * @throws \Cake\Core\Exception\CakeException
      * @return \CakePdf\Pdf\Engine\AbstractPdfEngine|null
      */
-    public function engine($name = null): ?AbstractPdfEngine
+    public function engine(string|array $name = null): ?AbstractPdfEngine
     {
         if ($name === null) {
             return $this->_engineClass;

--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -347,7 +347,7 @@ class CakePdf
             return (bool)file_put_contents($destination, $output);
         }
 
-        if (!$fileInfo->getPathInfo()->getRealPath()) {
+        if (!$fileInfo->getPathInfo()?->getRealPath()) {
             mkdir($fileInfo->getPath(), 0777, true);
         }
 

--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -361,7 +361,7 @@ class CakePdf
      * @throws \Cake\Core\Exception\CakeException
      * @return \CakePdf\Pdf\Engine\AbstractPdfEngine|null
      */
-    public function engine(string|array $name = null): ?AbstractPdfEngine
+    public function engine(string|array|null $name = null): ?AbstractPdfEngine
     {
         if ($name === null) {
             return $this->_engineClass;

--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -349,6 +349,7 @@ class CakePdf
         }
 
         $splFileInfo = $fileInfo->getPathInfo();
+        /** @phpstan-ignore-next-line */
         if ($splFileInfo === null) {
             throw new CakeException('Failed to retrieve path information');
         }

--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -332,6 +332,7 @@ class CakePdf
     /**
      * Writes output to file
      *
+     * @throws \Cake\Core\Exception\CakeException
      * @param string $destination Absolute file path to write to
      * @param bool $create Create file if it does not exist (if true)
      * @param string|null $html Html to write
@@ -347,7 +348,11 @@ class CakePdf
             return (bool)file_put_contents($destination, $output);
         }
 
-        if (!$fileInfo->getPathInfo()?->getRealPath()) {
+        $splFileInfo = $fileInfo->getPathInfo();
+        if ($splFileInfo === null) {
+            throw new CakeException('Failed to retrieve path information');
+        }
+        if (!$splFileInfo->getRealPath()) {
             mkdir($fileInfo->getPath(), 0777, true);
         }
 

--- a/src/Pdf/CakePdf.php
+++ b/src/Pdf/CakePdf.php
@@ -6,7 +6,7 @@ namespace CakePdf\Pdf;
 use Cake\Cache\Cache;
 use Cake\Core\App;
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Http\ServerRequestFactory;
 use Cake\Routing\Router;
 use CakePdf\Pdf\Crypto\AbstractPdfCrypto;
@@ -275,14 +275,14 @@ class CakePdf
      * Create pdf content from html. Can be used to write to file or with PdfView to display
      *
      * @param null|string $html Html content to render. If omitted, the template will be rendered with viewVars and layout that have been set.
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return string
      */
     public function output(?string $html = null): string
     {
         $Engine = $this->engine();
         if ($Engine === null) {
-            throw new Exception('Engine is not loaded');
+            throw new CakeException('Engine is not loaded');
         }
 
         if ($html === null) {
@@ -358,7 +358,7 @@ class CakePdf
      * Load PdfEngine
      *
      * @param string|array $name Classname of pdf engine without `Engine` suffix. For example `CakePdf.DomPdf`
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return \CakePdf\Pdf\Engine\AbstractPdfEngine|null
      */
     public function engine($name = null): ?AbstractPdfEngine
@@ -375,10 +375,10 @@ class CakePdf
         /** @var class-string<\CakePdf\Pdf\Engine\AbstractPdfEngine>|null $engineClassName */
         $engineClassName = App::className($name, 'Pdf/Engine', 'Engine');
         if ($engineClassName === null) {
-            throw new Exception(sprintf('Pdf engine "%s" not found', $name));
+            throw new CakeException(sprintf('Pdf engine "%s" not found', $name));
         }
         if (!is_subclass_of($engineClassName, AbstractPdfEngine::class)) {
-            throw new Exception('Pdf engines must extend "AbstractPdfEngine"');
+            throw new CakeException('Pdf engines must extend "AbstractPdfEngine"');
         }
         $this->_engineClass = new $engineClassName($this);
         $this->_engineClass->setConfig($config);
@@ -390,7 +390,7 @@ class CakePdf
      * Load PdfCrypto
      *
      * @param string|array $name Classname of crypto engine without `Crypto` suffix. For example `CakePdf.Pdftk`
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return \CakePdf\Pdf\Crypto\AbstractPdfCrypto
      */
     public function crypto($name = null): AbstractPdfCrypto
@@ -399,7 +399,7 @@ class CakePdf
             if ($this->_cryptoClass !== null) {
                 return $this->_cryptoClass;
             }
-            throw new Exception('Crypto is not loaded');
+            throw new CakeException('Crypto is not loaded');
         }
         $config = [];
         if (is_array($name)) {
@@ -409,10 +409,10 @@ class CakePdf
 
         $engineClassName = App::className($name, 'Pdf/Crypto', 'Crypto');
         if ($engineClassName === null || !class_exists($engineClassName)) {
-            throw new Exception(sprintf('Pdf crypto `%s` not found', $name));
+            throw new CakeException(sprintf('Pdf crypto `%s` not found', $name));
         }
         if (!is_subclass_of($engineClassName, AbstractPdfCrypto::class)) {
-            throw new Exception('Crypto engine must extend `AbstractPdfCrypto`');
+            throw new CakeException('Crypto engine must extend `AbstractPdfCrypto`');
         }
         $this->_cryptoClass = new $engineClassName($this);
         $this->_cryptoClass->config($config);
@@ -751,7 +751,7 @@ class CakePdf
      * array: list of permissions that are allowed
      *
      * @param null|bool|array|string $permissions Permissions to set
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return mixed
      */
     public function permissions($permissions = null)
@@ -775,11 +775,11 @@ class CakePdf
         if (is_array($permissions)) {
             foreach ($permissions as $permission) {
                 if (!in_array($permission, $this->_availablePermissions)) {
-                    throw new Exception(sprintf('Invalid permission: %s', $permission));
+                    throw new CakeException(sprintf('Invalid permission: %s', $permission));
                 }
 
                 if (!$this->crypto()->permissionImplemented($permission)) {
-                    throw new Exception(sprintf('Permission not implemented in crypto engine: %s', $permission));
+                    throw new CakeException(sprintf('Permission not implemented in crypto engine: %s', $permission));
                 }
             }
         }
@@ -793,7 +793,7 @@ class CakePdf
      * Get/Set caching.
      *
      * @param null|bool|string $cache Cache config name to use, If true is passed, 'cake_pdf' will be used.
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return mixed
      */
     public function cache($cache = null)
@@ -813,7 +813,7 @@ class CakePdf
         }
 
         if (!in_array($cache, Cache::configured())) {
-            throw new Exception(sprintf('CakePdf cache is not configured: %s', $cache));
+            throw new CakeException(sprintf('CakePdf cache is not configured: %s', $cache));
         }
 
         $this->_cache = $cache;

--- a/src/Pdf/Crypto/PdftkCrypto.php
+++ b/src/Pdf/Crypto/PdftkCrypto.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace CakePdf\Pdf\Crypto;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 
 class PdftkCrypto extends AbstractPdfCrypto
 {
@@ -34,7 +34,7 @@ class PdftkCrypto extends AbstractPdfCrypto
      * Encrypt a pdf file
      *
      * @param string $data raw pdf data
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return string raw pdf data
      */
     public function encrypt(string $data): string
@@ -47,7 +47,7 @@ class PdftkCrypto extends AbstractPdfCrypto
         }
 
         if (!is_executable($this->_binary)) {
-            throw new Exception(sprintf('pdftk binary is not found or not executable: %s', $this->_binary));
+            throw new CakeException(sprintf('pdftk binary is not found or not executable: %s', $this->_binary));
         }
 
         $arguments = [];
@@ -68,11 +68,11 @@ class PdftkCrypto extends AbstractPdfCrypto
         }
 
         if (!$ownerPassword && !$userPassword) {
-            throw new Exception('Crypto: Required to configure atleast an ownerPassword or userPassword');
+            throw new CakeException('Crypto: Required to configure atleast an ownerPassword or userPassword');
         }
 
         if ($ownerPassword == $userPassword) {
-            throw new Exception('Crypto: ownerPassword and userPassword cannot be the same');
+            throw new CakeException('Crypto: ownerPassword and userPassword cannot be the same');
         }
 
         $command = sprintf('%s - output - %s', $this->_binary, $this->_buildArguments($arguments));
@@ -96,7 +96,7 @@ class PdftkCrypto extends AbstractPdfCrypto
         $exitcode = proc_close($prochandle);
 
         if ($exitcode !== 0) {
-            throw new Exception(sprintf("Crypto: (exit code %d)\n%s", $exitcode, $stderr));
+            throw new CakeException(sprintf("Crypto: (exit code %d)\n%s", $exitcode, $stderr));
         }
 
         return (string)$stdout;

--- a/src/Pdf/Engine/TexToPdfEngine.php
+++ b/src/Pdf/Engine/TexToPdfEngine.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace CakePdf\Pdf\Engine;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use CakePdf\Pdf\CakePdf;
 
 class TexToPdfEngine extends AbstractPdfEngine
@@ -62,7 +62,7 @@ class TexToPdfEngine extends AbstractPdfEngine
     /**
      * Generates Pdf from html
      *
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return string raw pdf data
      */
     public function output(): string
@@ -71,15 +71,15 @@ class TexToPdfEngine extends AbstractPdfEngine
         $content = $this->_exec($this->_getCommand(), $texFile);
 
         if (strpos(mb_strtolower($content['stderr']), 'error')) {
-            throw new Exception('System error <pre>' . $content['stderr'] . '</pre>');
+            throw new CakeException('System error <pre>' . $content['stderr'] . '</pre>');
         }
 
         if (mb_strlen($content['stdout'], $this->_Pdf->encoding()) === 0) {
-            throw new Exception("TeX compiler binary didn't return any data");
+            throw new CakeException("TeX compiler binary didn't return any data");
         }
 
         if ((int)$content['return'] !== 0 && !empty($content['stderr'])) {
-            throw new Exception('Shell error, return code: ' . (int)$content['return']);
+            throw new CakeException('Shell error, return code: ' . (int)$content['return']);
         }
 
         $result = (string)file_get_contents($texFile . '.pdf');
@@ -142,7 +142,7 @@ class TexToPdfEngine extends AbstractPdfEngine
      * Get the command to render a pdf
      *
      * @return string the command for generating the pdf
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     protected function _getCommand(): string
     {
@@ -152,7 +152,7 @@ class TexToPdfEngine extends AbstractPdfEngine
             $this->_binary = $binary;
         }
         if (!is_executable($this->_binary)) {
-            throw new Exception(sprintf('TeX compiler binary is not found or not executable: %s', $this->_binary));
+            throw new CakeException(sprintf('TeX compiler binary is not found or not executable: %s', $this->_binary));
         }
 
         $options = (array)$this->getConfig('options');

--- a/src/Pdf/Engine/WkHtmlToPdfEngine.php
+++ b/src/Pdf/Engine/WkHtmlToPdfEngine.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace CakePdf\Pdf\Engine;
 
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use CakePdf\Pdf\CakePdf;
 
 class WkHtmlToPdfEngine extends AbstractPdfEngine
@@ -41,7 +41,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
     /**
      * Generates Pdf from html
      *
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      * @return string Raw PDF data
      * @throws \Exception If no output is generated to stdout by wkhtmltopdf.
      */
@@ -55,7 +55,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
         }
 
         if (!empty($content['stderr'])) {
-            throw new Exception(sprintf(
+            throw new CakeException(sprintf(
                 'System error "%s" when executing command "%s". ' .
                 'Try using the binary/package provided on http://wkhtmltopdf.org/downloads.html',
                 $content['stderr'],
@@ -63,7 +63,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
             ));
         }
 
-        throw new Exception("WKHTMLTOPDF didn't return any data");
+        throw new CakeException("WKHTMLTOPDF didn't return any data");
     }
 
     /**
@@ -98,7 +98,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
      * Get the command to render a pdf
      *
      * @return string the command for generating the pdf
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     protected function _getCommand(): string
     {
@@ -176,7 +176,7 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
                 }
             } elseif ($key === 'cover') {
                 if (!isset($value['url'])) {
-                    throw new Exception('The url for the cover is missing. Use the "url" index.');
+                    throw new CakeException('The url for the cover is missing. Use the "url" index.');
                 }
                 $command .= ' cover ' . escapeshellarg((string)$value['url']);
                 unset($value['url']);
@@ -222,6 +222,6 @@ class WkHtmlToPdfEngine extends AbstractPdfEngine
             return $binary;
         }
 
-        throw new Exception(sprintf('wkhtmltopdf binary is not found or not executable: %s', $binary));
+        throw new CakeException(sprintf('wkhtmltopdf binary is not found or not executable: %s', $binary));
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,22 +9,16 @@ class Plugin extends BasePlugin
 {
     /**
      * Load routes or not
-     *
-     * @var bool
      */
-    protected $routesEnabled = false;
+    protected bool $routesEnabled = false;
 
     /**
      * Enable middleware
-     *
-     * @var bool
      */
-    protected $middlewareEnabled = false;
+    protected bool $middlewareEnabled = false;
 
     /**
      * Console middleware
-     *
-     * @var bool
      */
-    protected $consoleEnabled = false;
+    protected bool $consoleEnabled = false;
 }

--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace CakePdf\View;
 
 use Cake\Core\Configure;
-use Cake\Core\Exception\Exception;
+use Cake\Core\Exception\CakeException;
 use Cake\Event\EventManager;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
@@ -15,17 +15,13 @@ class PdfView extends View
 {
     /**
      * The subdirectory.  PDF views are always in pdf.
-     *
-     * @var string
      */
-    protected $subDir = 'pdf';
+    protected string $subDir = 'pdf';
 
     /**
      * The name of the layouts subfolder containing layouts for this View.
-     *
-     * @var string
      */
-    protected $layoutPath = 'pdf';
+    protected string $layoutPath = 'pdf';
 
     /**
      * CakePdf Instance
@@ -39,7 +35,7 @@ class PdfView extends View
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'pdfConfig' => [],
     ];
 
@@ -51,7 +47,7 @@ class PdfView extends View
      * @param \Cake\Event\EventManager $eventManager Event manager instance.
      * @param array $viewOptions View options. See View::$_passedVars for list of
      *   options which get set as class properties.
-     * @throws \Cake\Core\Exception\Exception
+     * @throws \Cake\Core\Exception\CakeException
      */
     public function __construct(
         ?ServerRequest $request = null,
@@ -74,7 +70,7 @@ class PdfView extends View
 
         $pdfConfig = $this->getConfig('pdfConfig');
         if (empty($pdfConfig)) {
-            throw new Exception('No PDF config set. Use ViewBuilder::setOption(\'pdfConfig\', $config) to do so.');
+            throw new CakeException('No PDF config set. Use ViewBuilder::setOption(\'pdfConfig\', $config) to do so.');
         }
 
         $this->renderer($pdfConfig);
@@ -83,7 +79,7 @@ class PdfView extends View
     /**
      * Return CakePdf instance, optionally set engine to be used
      *
-     * @param array $config Array of pdf configs. When empty CakePdf instance will be returned.
+     * @param ?array $config Array of pdf configs. When empty CakePdf instance will be returned.
      * @return \CakePdf\Pdf\CakePdf|null
      */
     public function renderer(?array $config = null): ?CakePdf
@@ -98,7 +94,7 @@ class PdfView extends View
     /**
      * Render a Pdf view.
      *
-     * @param string $template The view being rendered.
+     * @param ?string $template The view being rendered.
      * @param false|null|string $layout The layout being rendered.
      * @return string The rendered view.
      */

--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -147,6 +147,4 @@ class PdfView extends View
 
         return strtolower($this->getTemplatePath()) . $id . '.pdf';
     }
-
-
 }

--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -123,13 +123,12 @@ class PdfView extends View
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritDoc
      */
     public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         return parent::getConfig($key, $default);
     }
-
 
     /**
      * Get or build a filename for forced download

--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -124,6 +124,12 @@ class PdfView extends View
         return $this->Blocks->get('content');
     }
 
+    public function getConfig(?string $key = null, mixed $default = null): mixed
+    {
+        return parent::getConfig($key, $default);
+    }
+
+
     /**
      * Get or build a filename for forced download
      *
@@ -140,4 +146,6 @@ class PdfView extends View
 
         return strtolower($this->getTemplatePath()) . $id . '.pdf';
     }
+
+
 }

--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -122,6 +122,9 @@ class PdfView extends View
         return $this->Blocks->get('content');
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function getConfig(?string $key = null, mixed $default = null): mixed
     {
         return parent::getConfig($key, $default);

--- a/src/View/PdfView.php
+++ b/src/View/PdfView.php
@@ -25,10 +25,8 @@ class PdfView extends View
 
     /**
      * CakePdf Instance
-     *
-     * @var \CakePdf\Pdf\CakePdf|null
      */
-    protected $_renderer;
+    protected ?CakePdf $_renderer = null;
 
     /**
      * Default config options.
@@ -42,9 +40,9 @@ class PdfView extends View
     /**
      * Constructor
      *
-     * @param \Cake\Http\ServerRequest $request Request instance.
-     * @param \Cake\Http\Response $response Response instance.
-     * @param \Cake\Event\EventManager $eventManager Event manager instance.
+     * @param ?\Cake\Http\ServerRequest $request Request instance.
+     * @param ?\Cake\Http\Response $response Response instance.
+     * @param ?\Cake\Event\EventManager $eventManager Event manager instance.
      * @param array $viewOptions View options. See View::$_passedVars for list of
      *   options which get set as class properties.
      * @throws \Cake\Core\Exception\CakeException
@@ -98,7 +96,7 @@ class PdfView extends View
      * @param false|null|string $layout The layout being rendered.
      * @return string The rendered view.
      */
-    public function render(?string $template = null, $layout = null): string
+    public function render(?string $template = null, string|false|null $layout = null): string
     {
         $content = parent::render($template, $layout);
 

--- a/tests/TestCase/Pdf/CakePdfTest.php
+++ b/tests/TestCase/Pdf/CakePdfTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace CakePdf\Test\TestCase\Pdf;
 
 use Cake\Core\Configure;
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\Exception;
 use Cake\TestSuite\TestCase;
 use CakePdf\Pdf\CakePdf;
@@ -40,7 +41,7 @@ class CakePdfTest extends TestCase
      */
     public function testNonExistingEngineException()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
 
         $config = ['engine' => 'NonExistingEngine'];
         new CakePdf($config);

--- a/tests/TestCase/Pdf/CakePdfTest.php
+++ b/tests/TestCase/Pdf/CakePdfTest.php
@@ -5,7 +5,6 @@ namespace CakePdf\Test\TestCase\Pdf;
 
 use Cake\Core\Configure;
 use Cake\Core\Exception\CakeException;
-use Cake\Core\Exception\Exception;
 use Cake\TestSuite\TestCase;
 use CakePdf\Pdf\CakePdf;
 use TestApp\Pdf\Engine\PdfTestEngine;

--- a/tests/TestCase/Pdf/Engine/DomPdfEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/DomPdfEngineTest.php
@@ -27,7 +27,7 @@ class DomPdfEngineTest extends TestCase
      */
     public function testReceiveOptions()
     {
-        $engineClass = $this->getMockClass(DomPdfEngine::class, ['_createInstance']);
+        $engineClass = $this->getMockBuilder(DomPdfEngine::class)->disableOriginalConstructor()->onlyMethods(['_createInstance'])->getMock()::class;
 
         $Pdf = new CakePdf([
             'engine' => [
@@ -65,8 +65,7 @@ class DomPdfEngineTest extends TestCase
      */
     public function testSetOptions()
     {
-        $engineClass = $this->getMockClass(DomPdfEngine::class, ['_output']);
-
+        $engineClass = $this->getMockBuilder(DomPdfEngine::class)->disableOriginalConstructor()->onlyMethods(['_output'])->getMock()::class;
         $Pdf = new CakePdf([
             'engine' => [
                 'className' => '\\' . $engineClass,
@@ -114,11 +113,14 @@ class DomPdfEngineTest extends TestCase
      */
     public function testControlFlow()
     {
-        $engineClass = $this->getMockClass(DomPdfEngine::class, [
-            '_createInstance',
-            '_render',
-            '_output',
-        ]);
+        $engineClass = $this->getMockBuilder(DomPdfEngine::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                '_createInstance',
+                '_render',
+                '_output',
+            ])
+            ->getMock()::class;
 
         $Pdf = new CakePdf([
             'engine' => '\\' . $engineClass,
@@ -149,7 +151,10 @@ class DomPdfEngineTest extends TestCase
      */
     public function testDompdfControlFlow()
     {
-        $engineClass = $this->getMockClass(DomPdfEngine::class, ['_createInstance']);
+        $engineClass = $this->getMockBuilder(DomPdfEngine::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_createInstance'])
+            ->getMock()::class;
 
         $Pdf = new CakePdf([
             'engine' => '\\' . $engineClass,

--- a/tests/TestCase/Pdf/Engine/MpdfEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/MpdfEngineTest.php
@@ -27,7 +27,10 @@ class MpdfEngineTest extends TestCase
      */
     public function testSetOptions()
     {
-        $engineClass = $this->getMockClass(MpdfEngine::class, ['_createInstance']);
+        $engineClass = $this->getMockBuilder(MpdfEngine::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_createInstance'])
+            ->getMock()::class;
 
         $Pdf = new CakePdf([
             'engine' => [

--- a/tests/TestCase/Pdf/Engine/WkHtmlToPdfEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/WkHtmlToPdfEngineTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CakePdf\Test\TestCase\Pdf\Engine;
 
+use Cake\Core\Exception\CakeException;
 use Cake\Core\Exception\Exception;
 use Cake\TestSuite\TestCase;
 use CakePdf\Pdf\CakePdf;
@@ -154,7 +155,7 @@ class WkHtmlToPdfEngineTest extends TestCase
             $this->markTestSkipped('wkhtmltopdf not found');
         }
 
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('The url for the cover is missing. Use the "url" index.');
 
         $class = new \ReflectionClass(WkHtmlToPdfEngine::class);
@@ -176,7 +177,7 @@ class WkHtmlToPdfEngineTest extends TestCase
 
     public function testGetBinaryPath()
     {
-        $this->expectException(Exception::class);
+        $this->expectException(CakeException::class);
         $this->expectExceptionMessage('wkhtmltopdf binary is not found or not executable: /foo/bar');
 
         $Pdf = new CakePdf([

--- a/tests/TestCase/Pdf/Engine/WkHtmlToPdfEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/WkHtmlToPdfEngineTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace CakePdf\Test\TestCase\Pdf\Engine;
 
 use Cake\Core\Exception\CakeException;
-use Cake\Core\Exception\Exception;
 use Cake\TestSuite\TestCase;
 use CakePdf\Pdf\CakePdf;
 use CakePdf\Pdf\Engine\WkHtmlToPdfEngine;


### PR DESCRIPTION
Since CakePHP 5 was released recently, this branch tries to get CakePdf running with it.

It's a first rough draft (tested with CakePHP 5.0.0 and PHP 8.1.2 and 8.2.8 and Mpdf v8.2.0).

I can not say if this really still works with cakephp 2 / phpunit 8 / phpunit 9 (i guess not, but did not find the time to test it yet). I also do not know if such backwards compatibility is desired by the maintainers of this package or unnecessary effort.

But: i would love to get the Cake 5 adoption process started, so here is the first draft.

Another open topic: As the RequestHandlerComponent was removed, the guidance (and probably also the code) regarding content negotiation needs to be updated