### PR TITLE
Support for Weasyprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Engines included in the plugin:
 * Mpdf (^8.0.4)
 * Tcpdf (^6.3)
 * WkHtmlToPdf **RECOMMENDED ENGINE**
+* WeasyPrint (** best: fast and high fidelity** if you have the privileges to install something on your server - [https://doc.courtbouillon.org/weasyprint/stable/first_steps.html])
 
 Community maintained engines:
 * [PDFreactor](https://github.com/jmischer/cake-pdfreactor)
@@ -18,7 +19,7 @@ Community maintained engines:
 
 ## Requirements
 
-* One of the following render engines: DomPdf, Mpdf, Tcpdf or wkhtmltopdf
+* One of the following render engines: DomPdf, Mpdf, Tcpdf, wkhtmltopdf or WeasyPrint
 * pdftk (optional) See: http://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/
 
 
@@ -78,6 +79,7 @@ Configuration options:
   * cwd: current working directory (Only for wkhtmltopdf)
   * options: Engine specific options. Currently used for following engine:
     * `WkHtmlToPdfEngine`: The options are passed as CLI arguments
+    * `WeasyprintEngine`: The options are passed as CLI arguments
     * `TexToPdfEngine`: The options are passed as CLI arguments
     * `DomPdfEngine`: The options are passed to constructor of `Dompdf` class
     * `MpdfEngine`: The options are passed to constructor of `Mpdf` class

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Engines included in the plugin:
 * Mpdf (^8.0.4)
 * Tcpdf (^6.3)
 * WkHtmlToPdf **RECOMMENDED ENGINE**
-* WeasyPrint (** best: fast and high fidelity** if you have the privileges to install something on your server - [https://doc.courtbouillon.org/weasyprint/stable/first_steps.html])
+* WeasyPrint (**best: fast and high fidelity** if you have the privileges to install something on your server - [https://doc.courtbouillon.org/weasyprint/stable/first_steps.html])
 
 Community maintained engines:
 * [PDFreactor](https://github.com/jmischer/cake-pdfreactor)

--- a/src/Pdf/Engine/WeasyprintEngine.php
+++ b/src/Pdf/Engine/WeasyprintEngine.php
@@ -1,0 +1,223 @@
+<?php
+declare(strict_types=1);
+
+namespace CakePdf\Pdf\Engine;
+
+use Cake\Core\Exception\CakeException;
+use CakePdf\Pdf\CakePdf;
+
+class WeasyprintEngine extends AbstractPdfEngine
+{
+    /**
+     * Path to the weasyprint executable binary
+     *
+     * @var string
+     */
+    protected string $_binary = 'weasyprint';
+
+    /**
+     * Flag to indicate if the environment is windows
+     *
+     * @var bool
+     */
+    protected bool $_windowsEnvironment;
+
+    /**
+     * Constructor
+     *
+     * @param \CakePdf\Pdf\CakePdf $Pdf CakePdf instance
+     */
+    public function __construct(CakePdf $Pdf)
+    {
+        parent::__construct($Pdf);
+
+        $this->_windowsEnvironment = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
+
+        if ($this->_windowsEnvironment) {
+            $this->_binary = 'C:/Progra~1/WeasyPrint/bin/weasyprint.exe';
+        }
+    }
+
+    /**
+     * Generates Pdf from html
+     *
+     * @throws \Cake\Core\Exception\CakeException
+     * @return string Raw PDF data
+     * @throws \Exception If no output is generated to stdout by weasyprint.
+     */
+    public function output(): string
+    {
+        $command = $this->_getCommand();
+        $content = $this->_exec($command, $this->_Pdf->html());
+
+        if (!empty($content['stdout'])) {
+            return $content['stdout'];
+        }
+
+        if (!empty($content['stderr'])) {
+            throw new CakeException(sprintf(
+                'System error "%s" when executing command "%s". ' .
+                'Try using the binary/package provided on http://weasyprint.org/downloads.html',
+                $content['stderr'],
+                $command
+            ));
+        }
+
+        throw new CakeException("weasyprint didn't return any data");
+    }
+
+    /**
+     * Execute the weasyprint commands for rendering pdfs
+     *
+     * @param string $cmd the command to execute
+     * @param string $input Html to pass to weasyprint
+     * @return array the result of running the command to generate the pdf
+     */
+    protected function _exec(string $cmd, string $input): array
+    {
+        $result = ['stdout' => '', 'stderr' => '', 'return' => ''];
+
+        $cwd = $this->getConfig('cwd');
+
+        $proc = proc_open($cmd, [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes, $cwd);
+        if ($proc === false) {
+            throw new CakeException('Unable to execute weasyprint, proc_open() failed');
+        }
+
+        fwrite($pipes[0], $input);
+        fclose($pipes[0]);
+
+        $result['stdout'] = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+
+        $result['stderr'] = stream_get_contents($pipes[2]);
+        fclose($pipes[2]);
+
+        $result['return'] = proc_close($proc);
+
+        return $result;
+    }
+
+    /**
+     * Get the command to render a pdf
+     *
+     * @return string the command for generating the pdf
+     * @throws \Cake\Core\Exception\CakeException
+     */
+    protected function _getCommand(): string
+    {
+        $binary = $this->getBinaryPath();
+
+        $options = [
+            'dpi'   => 96,
+            
+        ];
+
+        $margin = $this->_Pdf->margin();
+        foreach ($margin as $key => $value) {
+            if ($value !== null) {
+                $options['margin-' . $key] = $value . 'mm';
+            }
+        }
+        $options = array_merge($options, (array)$this->getConfig('options'));
+
+        if ($this->_windowsEnvironment) {
+            $command = '"' . $binary . '"';
+        } else {
+            $command = $binary;
+        }
+
+        foreach ($options as $key => $value) {
+            if (!$value) {
+                continue;
+            }
+            $command .= $this->parseOptions($key, $value);
+        }
+        /** @var array $footer */
+        $footer = $this->_Pdf->footer();
+        foreach ($footer as $location => $text) {
+            if ($text !== null) {
+                $command .= " --footer-$location \"" . addslashes($text) . '"';
+            }
+        }
+
+        /** @var array $header */
+        $header = $this->_Pdf->header();
+        foreach ($header as $location => $text) {
+            if ($text !== null) {
+                $command .= " --header-$location \"" . addslashes($text) . '"';
+            }
+        }
+        $command .= ' - -';
+
+        return $command;
+    }
+
+    /**
+     * Parses a value of options to create a part of the command.
+     * Created to reuse logic to parse the cover and toc options.
+     *
+     * @param string $key the option key name
+     * @param array|string|float|true $value the option value
+     * @return string part of the command
+     */
+    protected function parseOptions(string $key, string|bool|array|float $value): string
+    {
+        $command = '';
+        if (is_array($value)) {
+            if ($key === 'toc') {
+                $command .= ' toc';
+                foreach ($value as $k => $v) {
+                    $command .= $this->parseOptions($k, $v);
+                }
+            } elseif ($key === 'cover') {
+                if (!isset($value['url'])) {
+                    throw new CakeException('The url for the cover is missing. Use the "url" index.');
+                }
+                $command .= ' cover ' . escapeshellarg((string)$value['url']);
+                unset($value['url']);
+                foreach ($value as $k => $v) {
+                    $command .= $this->parseOptions($k, $v);
+                }
+            } else {
+                foreach ($value as $k => $v) {
+                    $command .= sprintf(' --%s %s %s', $key, escapeshellarg($k), escapeshellarg((string)$v));
+                }
+            }
+        } elseif ($value === true) {
+            if ($key === 'toc') {
+                $command .= ' toc';
+            } else {
+                $command .= ' --' . $key;
+            }
+        } else {
+            if ($key === 'cover') {
+                $command .= ' cover ' . escapeshellarg((string)$value);
+            } else {
+                $command .= sprintf(' --%s %s', $key, escapeshellarg((string)$value));
+            }
+        }
+
+        return $command;
+    }
+
+    /**
+     * Get path to weasyprint binary.
+     *
+     * @return string
+     */
+    public function getBinaryPath(): string
+    {
+        $binary = $this->getConfig('binary', $this->_binary);
+
+        /** @psalm-suppress ForbiddenCode */
+        if (
+            is_executable($binary) ||
+            (!$this->_windowsEnvironment && shell_exec('which ' . escapeshellarg($binary)))
+        ) {
+            return $binary;
+        }
+
+        throw new CakeException(sprintf('weasyprint binary is not found or not executable: %s', $binary));
+    }
+}

--- a/tests/TestCase/Pdf/Engine/WeasyprintEngineTest.php
+++ b/tests/TestCase/Pdf/Engine/WeasyprintEngineTest.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+namespace CakePdf\Test\TestCase\Pdf\Engine;
+
+use Cake\Core\Exception\CakeException;
+use Cake\TestSuite\TestCase;
+use CakePdf\Pdf\CakePdf;
+use CakePdf\Pdf\Engine\WeasyprintEngine;
+use ReflectionClass;
+
+/**
+ * WeasyprintEngineTest class
+ */
+class WeasyprintEngineTest extends TestCase
+{
+    /**
+     * Tests that the engine generates the right command
+     */
+    public function testGetCommand()
+    {
+        if (!shell_exec('which weasyprint')) {
+            $this->markTestSkipped('weasyprint not found');
+        }
+
+        $class = new ReflectionClass(WeasyprintEngine::class);
+        $method = $class->getMethod('_getCommand');
+        $method->setAccessible(true);
+
+        // Default options only
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+            ],
+        ]);
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' - -";
+        $this->assertEquals($expected, $result);
+
+        // A falsy option (false) must be skipped; a string option must be included
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+                'options' => [
+                    'quiet' => false,
+                    'encoding' => 'UTF-8',
+                ],
+            ],
+        ]);
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' --encoding 'UTF-8' - -";
+        $this->assertEquals($expected, $result);
+
+        // With all margins set to 0
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+            ],
+            'margin' => [
+                'bottom' => 0,
+                'left' => 0,
+                'right' => 0,
+                'top' => 0,
+            ],
+        ]);
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' --margin-bottom '0mm' --margin-left '0mm' --margin-right '0mm' --margin-top '0mm' - -";
+        $this->assertEquals($expected, $result);
+
+        // Various option types: boolean, string, integer, associative array
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+                'options' => [
+                    'boolean' => true,
+                    'string' => 'value',
+                    'integer' => 42,
+                    'array' => [
+                        'first' => 'firstValue',
+                        'second' => 'secondValue',
+                    ],
+                ],
+            ],
+        ]);
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' --boolean --string 'value' --integer '42' --array 'first' 'firstValue' --array 'second' 'secondValue' - -";
+        $this->assertEquals($expected, $result);
+
+        // With footer and header
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+            ],
+        ]);
+        $Pdf->footer('Footer left');
+        $Pdf->header(null, 'Page {page}');
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' --footer-left \"Footer left\" --header-center \"Page {page}\" - -";
+        $this->assertEquals($expected, $result);
+
+        // With cover (string) and toc (boolean true)
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+                'options' => [
+                    'cover' => 'cover.html',
+                    'toc' => true,
+                ],
+            ],
+        ]);
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' cover 'cover.html' toc - -";
+        $this->assertEquals($expected, $result);
+
+        // With cover (array) and toc (array of options)
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+                'options' => [
+                    'cover' => [
+                        'url' => 'cover.html',
+                        'enable-smart-shrinking' => true,
+                        'zoom' => 10,
+                    ],
+                    'toc' => [
+                        'zoom' => 5,
+                        'encoding' => 'ISO-8859-1',
+                    ],
+                ],
+            ],
+        ]);
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' cover 'cover.html' --enable-smart-shrinking --zoom '10' toc --zoom '5' --encoding 'ISO-8859-1' - -";
+        $this->assertEquals($expected, $result);
+
+        // With global zoom override alongside cover (array) and toc (array)
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+                'options' => [
+                    'zoom' => 4,
+                    'cover' => [
+                        'url' => 'cover.html',
+                        'enable-smart-shrinking' => true,
+                        'zoom' => 10,
+                    ],
+                    'toc' => [
+                        'disable-dotted-lines' => true,
+                        'xsl-style-sheet' => 'style.xsl',
+                        'zoom' => 5,
+                        'encoding' => 'ISO-8859-1',
+                    ],
+                ],
+            ],
+        ]);
+        $result = $method->invokeArgs($Pdf->engine(), []);
+        $expected = "weasyprint --dpi '96' --zoom '4' cover 'cover.html' --enable-smart-shrinking --zoom '10' toc --disable-dotted-lines --xsl-style-sheet 'style.xsl' --zoom '5' --encoding 'ISO-8859-1' - -";
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testCoverUrlMissing()
+    {
+        if (!shell_exec('which weasyprint')) {
+            $this->markTestSkipped('weasyprint not found');
+        }
+
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('The url for the cover is missing. Use the "url" index.');
+
+        $class = new ReflectionClass(WeasyprintEngine::class);
+        $method = $class->getMethod('_getCommand');
+        $method->setAccessible(true);
+
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+                'options' => [
+                    'cover' => [
+                        'enable-smart-shrinking' => true,
+                        'zoom' => 10,
+                    ],
+                ],
+            ],
+        ]);
+        $method->invokeArgs($Pdf->engine(), []);
+    }
+
+    public function testGetBinaryPath()
+    {
+        $this->expectException(CakeException::class);
+        $this->expectExceptionMessage('weasyprint binary is not found or not executable: /foo/bar');
+
+        $Pdf = new CakePdf([
+            'engine' => [
+                'className' => 'CakePdf.Weasyprint',
+                'binary' => '/foo/bar',
+            ],
+        ]);
+
+        /** @var \CakePdf\Pdf\Engine\WeasyprintEngine $engine */
+        $engine = $Pdf->engine();
+        $engine->getBinaryPath();
+    }
+}


### PR DESCRIPTION
I've added support for weasyprint, a wonderful php engine which is not well known but is incredibly powerful
[https://weasyprint.org/]

It's my choice instead of wkhtmltopdf for producing fast and professional documents. It supports CSS3, and formatting the documents is a dream compared to the other engines.

In the code:
- I've added the engine
- I've updated the README
